### PR TITLE
Fix events getting lost at high concurrency

### DIFF
--- a/lib/revisionGuard.js
+++ b/lib/revisionGuard.js
@@ -152,7 +152,7 @@ RevisionGuard.prototype = {
 
         if (revInEvt === revInStore) {
           debug('revision match [concatenatedId]=' + concatenatedId + ', [revInStore]=' + revInStore + ', [revInEvt]=' + revInEvt);
-          return;
+          return this.guard(evt, callback);
         }
 
         if (loopCount < self.options.queueTimeoutMaxLoops) {

--- a/lib/revisionGuard.js
+++ b/lib/revisionGuard.js
@@ -152,7 +152,7 @@ RevisionGuard.prototype = {
 
         if (revInEvt === revInStore) {
           debug('revision match [concatenatedId]=' + concatenatedId + ', [revInStore]=' + revInStore + ', [revInEvt]=' + revInEvt);
-          return this.guard(evt, callback);
+          return self.guard(evt, callback);
         }
 
         if (loopCount < self.options.queueTimeoutMaxLoops) {


### PR DESCRIPTION
When an event is out of order, it gets put on the order queue which uses a timeout to "check" if any older events have already arrived. In high concurrency environments this "out of order" situation occurs more often, and sometimes caused events to get lost.

The queueEvent function defines what to do when the timer has passed, but when it finds that the current event being checked matches the current revision, it does not actually call back to resolve that event.

Because of this the revision would no longer be updated and all future events related to that aggregate would get stuck.

This PR fixes that issue by calling `guard` again whenever an event matches the proper revision.

NOTE: I'm not sure if you prefer `finishGuard` to be called instead of `guard`. It would be better for perf (since less checks are done), but it could cause other subtle bugs since some checks are skipped.